### PR TITLE
Fixed codelists2ttl.py and upload_changes.py #6

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,8 +2,8 @@
 
 ## Overview
 
-The scripts in this directory are used to manage the WCMP2 codelists publication to
-the WMO Codes Registry.
+The scripts in this directory are used to manage the WCMP2 (WMO Core Metadata Profile 2.0)
+codelists publication to the WMO Codes Registry.
 
 ## The WMO Codes Registry
 
@@ -12,12 +12,12 @@ provides a number of registers defining controlled vocabularies used in various
 WMO standards and systems.
 
 The service provides an API in support of automated workflow to manage codelist
-registers.  The API is available as follows:
+registers. The API is available as follows:
 
 - https://ci.codes.wmo.int: testing
 - https://codes.wmo.int: production
 
-API usage requires an account and credentials.  Contact WMO Secretariat to be
+API usage requires an account and credentials. Contact WMO Secretariat to be
 provided access to the WMO Codes Registry API (a GitHub user id is required).
 
 Once you receive access, an API Key is required to manage resources on the registry.
@@ -40,13 +40,16 @@ where:
 
 Managing WCMP2 codelists publication to the WMO Codes Registry involves the following steps:
 
-- creating the `wis` register
+- creating the `wis` register - needed only once, mentioned only for completeness
 - generating TTL files from CSV
 - publishing TTL files to the WMO Codes Registry
 
 ### Creating the `wis` register
 
-TODO
+Use yje action/button "Create register" in the web UI of the WMO Codes Registry and fill following attributes:
+- Notation
+- Label
+- Description
 
 ### Generating TTLs
 
@@ -60,7 +63,7 @@ This will create all TTL files in a directory called `wis`.
 
 ### Publishing TTLs
 
-To generate TTL files, from the root of the repository, run the following command:
+To upload TTL files, from the root of the repository, run the following command:
 
 ```bash
 python3 scripts/upload_changes.py https://api.github.com/users/{user_id} <password> <environment> <output-directory> <status>
@@ -71,7 +74,10 @@ where:
 - `user_id` is your GitHub userid
 - `password` is the API Key (see the [#overview](Overview) with instructions on how to generate an API Key
 - `environment` is whether to upload change to the testing or production environment
-- `output-directory` is the resulting directly where TTL outputs should published from
+- `output-directory` is the resulting directly where TTL outputs should published from, that is `wis`
+- `status` is either `experimental` or `stable`, please note that this value cannot be changed on existing entries
+
+The script has a few more options, notably `-h` that displays help.
 
 Examples:
 

--- a/scripts/codelists2ttl.py
+++ b/scripts/codelists2ttl.py
@@ -185,9 +185,4 @@ with root_table.open() as fh:
 
                     fh3.write(ttl)
 
-    register_ttl_file = ttl_files_path / 'wis.ttl'
-    print(f'Generating {register_ttl_file}')
-    with register_ttl_file.open('w') as fh:
-        fh.write(gen_skos_register(subregisters))
-
 print('Done')

--- a/scripts/upload_changes.py
+++ b/scripts/upload_changes.py
@@ -160,7 +160,7 @@ def upload(session: requests.Session, url: str, payload: str,
     # to check existence adjust the URL
     url_to_check = url + '/'
     if verbose:
-        print(f'  Checking {url_to_check} - ', end=" ")
+        print(f'  Checking {url_to_check} - ', end=' ')
 
     response = session.get(url_to_check, headers=HEADERS)
 

--- a/scripts/upload_changes.py
+++ b/scripts/upload_changes.py
@@ -117,12 +117,10 @@ def put(session: requests.Session, url: str, payload: str,
     """
 
     params = {
-        'status': status
+        'status': status,
+        'non-member-properties': 'true'
     }
 
-    # for register update adjust the URL
-    if 'reg:Register' in payload:
-        url += '?non-member-properties'
     if not dry_run:
         if verbose:
             print(f'  HTTP PUT to: {url}')
@@ -159,10 +157,12 @@ def upload(session: requests.Session, url: str, payload: str,
     :returns: `None`
     """
 
+    # to check existence adjust the URL
+    url_to_check = url + '/'
     if verbose:
-        print(f'  Checking {url} - ', end=" ")
+        print(f'  Checking {url_to_check} - ', end=" ")
 
-    response = session.get(url, headers=HEADERS)
+    response = session.get(url_to_check, headers=HEADERS)
 
     if response.status_code == 200:
         if verbose:
@@ -236,7 +236,9 @@ if __name__ == '__main__':
     if not Path(args.directory).is_dir():
         raise ValueError(f'Directory {args.directory} does not exists.')
     if args.mode not in ['test', 'prod']:
-        raise ValueError('Mode must be either test or prod')
+        raise ValueError('Mode must be either "test" or "prod"')
+    if args.status not in ['stable', 'experimental']:
+        raise ValueError('Mode must be either "stable" or "experimental"')
     if args.mode == 'prod':
         REGISTRY = PROD_REGISTRY
 

--- a/scripts/upload_changes.py
+++ b/scripts/upload_changes.py
@@ -38,7 +38,7 @@ def authenticate(base_url: str, user_id: str,
 
     :param base_url: base URL of registry API
     :param user_id: User ID
-    :param passwor: password
+    :param password: password
 
     :returns: Session for further interaction upon successful login
     """
@@ -62,7 +62,7 @@ def authenticate(base_url: str, user_id: str,
 
 
 def post(session: requests.Session, url: str, payload: str,
-         dry_run: bool, verbose: bool, status: str = 'experimental') -> None:
+         dry_run: bool, verbose: bool, status: str) -> None:
     """
     Posts new content to the intended parent register
 
@@ -71,7 +71,7 @@ def post(session: requests.Session, url: str, payload: str,
     :param payload: HTTP POST payload
     :param dry_run: whether to run as a dry run (simulates request only)
     :param verbose: whether to provide verbose output
-    :param status: publication status (experimental [default], stable)
+    :param status: publication status (experimental, stable)
 
     :returns: `None`
     """
@@ -102,7 +102,7 @@ def post(session: requests.Session, url: str, payload: str,
 
 
 def put(session: requests.Session, url: str, payload: str,
-        dry_run: bool, verbose: bool, status: str = 'experimental') -> None:
+        dry_run: bool, verbose: bool, status: str) -> None:
     """
     Updates definition of a register or entity.
 
@@ -111,7 +111,7 @@ def put(session: requests.Session, url: str, payload: str,
     :param payload: HTTP POST payload
     :param dry_run: whether to run as a dry run (simulates request only)
     :param verbose: whether to provide verbose output
-    :param status: publication status (experimental [default], stable)
+    :param status: publication status (experimental, stable)
 
     :returns: `None`
     """
@@ -145,7 +145,7 @@ def put(session: requests.Session, url: str, payload: str,
 
 
 def upload(session: requests.Session, url: str, payload: str,
-           dry_run: bool, verbose: bool) -> None:
+           dry_run: bool, verbose: bool, status: str) -> None:
     """
     PUTs or POSTs given data depending if it already exists or not
 
@@ -154,24 +154,25 @@ def upload(session: requests.Session, url: str, payload: str,
     :param payload: HTTP POST payload
     :param dry_run: whether to run as a dry run (simulates request only)
     :param verbose: whether to provide verbose output
+    :param status: publication status (experimental, stable)
 
     :returns: `None`
     """
 
     if verbose:
-        print(f'  Checking {url}')
+        print(f'  Checking {url} - ', end=" ")
 
     response = session.get(url, headers=HEADERS)
 
     if response.status_code == 200:
         if verbose:
             print('Existing entry, using PUT')
-        put(session, url, payload, dry_run, verbose)
+        put(session, url, payload, dry_run, verbose, status)
     elif response.status_code == 404:
         if verbose:
             print('New entry, using POST')
         url = '/'.join(url.split('/')[:-1])
-        post(session, url, payload, dry_run, verbose)
+        post(session, url, payload, dry_run, verbose, status)
     else:
         raise ValueError(
             f'Cannot upload to {url}: {response.status_code} {response.reason}: {response.content.decode("utf-8")}'  # noqa
@@ -179,15 +180,16 @@ def upload(session: requests.Session, url: str, payload: str,
 
 
 def upload_file(session: requests.Session, url: str, filepath: Path,
-                dry_run: bool, verbose: bool) -> None:
+                dry_run: bool, verbose: bool, status: str) -> None:
     """
     Uploads given TTL file to the registry
 
     :param session: API session
     :param url: URL of HTTP POST
-    :param filepath : `path.Path` of filepath
+    :param filepath: `path.Path` of filepath
     :param dry_run: whether to run as a dry run (simulates request only)
     :param verbose: whether to provide verbose output
+    :param status: publication status (experimental, stable)
 
     :returns: `None`
     """
@@ -200,7 +202,7 @@ def upload_file(session: requests.Session, url: str, filepath: Path,
         url = f'{url}/{rel_id}'
 
         print(f'Uploading {filepath} to {url}')
-        upload(session, url, ttl_data, dry_run, verbose)
+        upload(session, url, ttl_data, dry_run, verbose, status)
 
     return
 


### PR DESCRIPTION
codelists2ttl.py 
- no longer generates wis.ttl - we are not going to change this top-level register once the WIS specification is published, so it can remain a manual process.
upload_changes.py
- Fixed status handling and a few typos.
- Fixed checking of sub-register existence and a few other minor issues.
